### PR TITLE
Add support for setting the mdc prefix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Enhanced configuration:
             <includeRawMessage>false</includeRawMessage>
             <includeMarker>true</includeMarker>
             <includeMdcData>true</includeMdcData>
+            <mdcPrefix></mdcPrefix>
             <includeCallerData>false</includeCallerData>
             <includeRootCauseData>false</includeRootCauseData>
             <messageLayout class="ch.qos.logback.classic.PatternLayout">
@@ -101,6 +102,7 @@ Enhanced configuration:
   Default: false.
 * **includeMarker**: If true, logback markers will be included, too. Default: true.
 * **includeMdcData**: If true, MDC keys/values will be included, too. Default: true.
+* **mdcPrefix**: the key under which MDC values are stored. If empty or `null` MDC values will be written in the main object and can potentially overwrite other fields like level or message. Default: `"mdc"`.
 * **includeCallerData**: If true, caller data (source file-, method-, class name and line) will be
   included, too. Default: false.
 * **includeRootCauseData**: If true, root cause exception of the exception passed with the log

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     api 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.5.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
     testImplementation 'com.google.guava:guava:28.1-jre'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.10.1'

--- a/src/main/java/de/siegmar/logbackawslogsjsonencoder/AwsJsonLogEncoder.java
+++ b/src/main/java/de/siegmar/logbackawslogsjsonencoder/AwsJsonLogEncoder.java
@@ -19,13 +19,11 @@
 
 package de.siegmar.logbackawslogsjsonencoder;
 
-import ch.qos.logback.classic.PatternLayout;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.IThrowableProxy;
-import ch.qos.logback.core.encoder.EncoderBase;
-import org.slf4j.Marker;
-
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -34,6 +32,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+
+import org.slf4j.Marker;
+
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.core.encoder.EncoderBase;
 
 /**
  * Logback encoder that produces JSON that is read by CloudWatch Logs Insights.

--- a/src/test/java/de/siegmar/logbackawslogsjsonencoder/AwsJsonLogEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackawslogsjsonencoder/AwsJsonLogEncoderTest.java
@@ -181,7 +181,7 @@ public class AwsJsonLogEncoderTest {
     @ParameterizedTest
     @ValueSource(strings = {"mdc", ""})
     @NullSource
-    public void mdcPrefix(String prefix) throws IOException {
+    public void mdcPrefix(final String prefix) throws IOException {
         encoder.setMdcPrefix(prefix);
         encoder.start();
 


### PR DESCRIPTION
If an empty string or null prefix is used the mdc values are written in the main object.