### PR TITLE
NOJIRA: Provide the option to include static fields at root level of JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,4 @@ Enhanced configuration:
 * **messageLayout**: Message format for messages without an exception. Default: `"%m%nopex"`.
 * **fullMessageLayout**: Message format for messages with an exception. Default: `"%m%n"`.
 * **staticFields**: Additional, static fields to include. Defaults: none.
+* **includeStaticFieldsAsJsonNode**: If false, static fields will be included at root level JSON. Default: true.

--- a/src/main/java/de/siegmar/logbackawslogsjsonencoder/AwsJsonLogEncoder.java
+++ b/src/main/java/de/siegmar/logbackawslogsjsonencoder/AwsJsonLogEncoder.java
@@ -104,6 +104,13 @@ public class AwsJsonLogEncoder extends EncoderBase<ILoggingEvent> {
      */
     private Map<String, Object> staticFields = new HashMap<>();
 
+    /**
+     * if false, static fields are added at the root level of JSON.
+     * if true, static fields are added under the property name `static_fields`.
+     * Default: true
+     */
+    private boolean includeStaticFieldsAsJsonNode = true;
+
     public String getDateTimeFormat() {
         return dateTimeFormat;
     }
@@ -170,6 +177,14 @@ public class AwsJsonLogEncoder extends EncoderBase<ILoggingEvent> {
 
     public Map<String, Object> getStaticFields() {
         return staticFields;
+    }
+
+    public boolean isIncludeStaticFieldsAsJsonNode() {
+        return includeStaticFieldsAsJsonNode;
+    }
+
+    public void setIncludeStaticFieldsAsJsonNode(final boolean includeStaticFieldsAsJsonNode) {
+        this.includeStaticFieldsAsJsonNode = includeStaticFieldsAsJsonNode;
     }
 
     public void setStaticFields(final Map<String, Object> staticFields) {
@@ -260,9 +275,8 @@ public class AwsJsonLogEncoder extends EncoderBase<ILoggingEvent> {
                         buildRootExceptionData(event.getThrowableProxy()));
                 }
 
-                if (!staticFields.isEmpty()) {
-                    json.appendToJSON("static_fields", staticFields);
-                }
+                appendStaticFields(json);
+
             }
 
             appendable.append(System.lineSeparator());
@@ -271,6 +285,14 @@ public class AwsJsonLogEncoder extends EncoderBase<ILoggingEvent> {
         }
 
         return bos.toByteArray();
+    }
+
+    private void appendStaticFields(final SimpleJsonEncoder json) {
+        if (includeStaticFieldsAsJsonNode) {
+            append(json, "static_fields", staticFields);
+        } else {
+            staticFields.forEach(json::appendToJSON);
+        }
     }
 
     private void append(final SimpleJsonEncoder json, final String key,

--- a/src/test/java/de/siegmar/logbackawslogsjsonencoder/AwsJsonLogEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackawslogsjsonencoder/AwsJsonLogEncoderTest.java
@@ -177,6 +177,27 @@ public class AwsJsonLogEncoderTest {
     }
 
     @Test
+    public void flattenStaticFields() throws IOException {
+        encoder.setIncludeRawMessage(true);
+        encoder.addStaticField("foo:bar");
+        encoder.setIncludeStaticFieldsAsJsonNode(false);
+        encoder.start();
+
+        final LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+        final Logger logger = lc.getLogger(LOGGER_NAME);
+
+        final LoggingEvent event = simpleLoggingEvent(logger, null);
+
+        final String logMsg = produce(event);
+
+        final ObjectMapper om = new ObjectMapper();
+        final JsonNode jsonNode = om.readTree(logMsg);
+        basicValidation(jsonNode);
+        assertEquals("DEBUG", jsonNode.get("level").textValue());
+        assertEquals("bar", jsonNode.get("foo").textValue());
+    }
+
+    @Test
     public void rootExceptionTurnedOff() throws IOException {
         encoder.start();
 


### PR DESCRIPTION
## Proposed Changes

Providing the optional flag `includeStaticFieldsAsJsonNode` if set true will include the static fields at root level rather than under `static_fields` property.

```
        <encoder class="de.siegmar.logbackawslogsjsonencoder.AwsJsonLogEncoder">
            <includeStaticFieldsAsJsonNode>false</includeStaticFieldsAsJsonNode>
            <staticField>app:user-services</staticField>
            <staticField>workload:identity-service</staticField>
        </encoder>
```

```
  {
	"timestamp": "2022-12-14T16:31:07.053000+0100",
	"level": "INFO",
	"logger": "🐳 [testcontainers\/ryuk:0.3.3]",
	"thread": "io-compute-blocker-2",
	"message": "Container testcontainers\/ryuk:0.3.3 is starting: 678863702bb93e7e319700e7992da400d15b1cb4152e36bae78c50b0c953f3a6",
	"app": "user-services",
	"workload": "identity-service"
  }
```
